### PR TITLE
修复 wx_notifier 逻辑

### DIFF
--- a/lib/fastlane/plugin/fir_cli/actions/fir_cli_action.rb
+++ b/lib/fastlane/plugin/fir_cli/actions/fir_cli_action.rb
@@ -34,8 +34,9 @@ module Fastlane
 
           wxwork_access_token: params[:wxwork_access_token],
           wxwork_custom_message: params[:wxwork_custom_message],
-          wxwork_pic_url: params[:wxwork_pic_url]
-
+          wxwork_pic_url: params[:wxwork_pic_url],
+          wxwork_webhook: ""
+          
         }.reject {|_k, v| v.nil?}
         answer = Helper::FirHelper.publish(fir_args, options)
         UI.message("fastlane-plugin-fir_cli answer: #{answer}")

--- a/lib/fastlane/plugin/fir_cli/actions/fir_cli_action.rb
+++ b/lib/fastlane/plugin/fir_cli/actions/fir_cli_action.rb
@@ -35,9 +35,13 @@ module Fastlane
           wxwork_access_token: params[:wxwork_access_token],
           wxwork_custom_message: params[:wxwork_custom_message],
           wxwork_pic_url: params[:wxwork_pic_url],
-          wxwork_webhook: ""
-          
+
         }.reject {|_k, v| v.nil?}
+        if options[:wxwork_access_token].blank?
+          options[:wxwork_webhook] = ""
+        else
+          options[:wxwork_webhook] = nil
+        end
         answer = Helper::FirHelper.publish(fir_args, options)
         UI.message("fastlane-plugin-fir_cli answer: #{answer}")
         answer

--- a/lib/fastlane/plugin/fir_cli/actions/fir_cli_action.rb
+++ b/lib/fastlane/plugin/fir_cli/actions/fir_cli_action.rb
@@ -34,7 +34,7 @@ module Fastlane
 
           wxwork_access_token: params[:wxwork_access_token],
           wxwork_custom_message: params[:wxwork_custom_message],
-          wxwork_pic_url: params[:wxwork_pic_url],
+          wxwork_pic_url: params[:wxwork_pic_url]
 
         }.reject {|_k, v| v.nil?}
         if options[:wxwork_access_token].blank?


### PR DESCRIPTION
修复 #26 
如果wxwork_access_token没有被传入，那么wxwork_webhook为"", wx_notifier不会继续执行下去
如果wxwork_access_token存在，那么wxwork_webhook为nil，webhook_url根据逻辑`webhook_url ||= "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=#{options[:wxwork_access_token]}"`生成，正常执行wx_notifier逻辑